### PR TITLE
Fix tests requiring a js dom environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
   "engines": {
     "node": "^16.0.0",
     "npm": "^7.0.0 || ^8.0.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
   }
 }


### PR DESCRIPTION
https://jestjs.io/docs/configuration#testenvironment-string

Tests can't be run otherwise.

```
 FAIL  test/scopedstorage.test.js
  ● ScopedStorage › sets an item

    The error below may be caused by using the wrong test environment, see https://jestjs.io/docs/configuration#testenvironment-string.
    Consider using the "jsdom" test environment.
    
    ReferenceError: window is not defined

      10 |
      11 |     beforeEach(() => {
    > 12 |         wrapped = window.localStorage
         |         ^
      13 |         storage = new ScopedStorage('test', wrapped, false)
      14 |     })
      15 |

      at Object.<anonymous> (test/scopedstorage.test.js:12:9)

```